### PR TITLE
ci: bump setup-uv to maintained tag scheme

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.0.0
 
       - name: Build the Pyodide output
         run: |

--- a/content/week05_ci/ci.md
+++ b/content/week05_ci/ci.md
@@ -284,7 +284,7 @@ tests:
   steps:
     - uses: actions/checkout@v4
 
-    - uses: astral-sh/setup-uv@v6
+    - uses: astral-sh/setup-uv@v8.0.0
 
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5


### PR DESCRIPTION
The old vX tags have been dropped to (force) (usually) better security practices. Dependabot will not update, however, leaving this v7 tag forever. Manually updating now.

See https://github.com/astral-sh/setup-uv/issues/830
