### PR TITLE
fix: correct typos, titles, and kernel handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ MyST MD course site for _Software Engineering for Scientific Computing_.
 | Slides                       | `npx @marp-team/marp-cli@latest --input-dir slides --output _output` |
 | Live dev server (JupyterLab) | `pixi run lab`                                                       |
 
-- `pixi run book` installs a user-wide ipykernel (`conda-env-se-for-sci-py`) and
+- `pixi run book` depends on the `install-kernel` task, which installs the
+  project's Python kernel into the pixi environment (`--sys-prefix`), then
   builds the site using `myst build --execute --html`. It sets
   `PYDEVD_DISABLE_FILE_VALIDATION=1`.
 - `mystmd` is configured to **execute all notebooks** on every build

--- a/content/week02_testing/testing.md
+++ b/content/week02_testing/testing.md
@@ -106,7 +106,7 @@ Here's a non-exhaustive list of some types of testing:
   this list...
 - **Property based testing** uses random inputs and verifies properties of the
   output. The Python tool for this is
-  [Hypothosis](https://hypothesis.readthedocs.io/en/latest/), which works with
+  [Hypothesis](https://hypothesis.readthedocs.io/en/latest/), which works with
   pytest. This also may be called "fuzzing".
 - **Smoke testing**: Making sure the code won't "catch fire". Checking an
   end-to-end ground truth.
@@ -259,7 +259,7 @@ Some Python testing frameworks:
   same name.
 - **xdoctest**: a better version of the standard library module that might even
   be usable in some cases.
-- **Hypothosis**: Property based testing (is an add-on to pytest)
+- **Hypothesis**: Property based testing (is an add-on to pytest)
 - [**ward**](https://github.com/darrenburns/ward): An abandoned library that
   tried to rethink pytest to be even more modern. Interesting to see the ideas
   here.

--- a/myst.yml
+++ b/myst.yml
@@ -62,7 +62,7 @@ project:
       children:
         - file: content/week07_design/designpatt.md
         - file: content/week07_design/functional.md
-    - title: "Week 8: Static Typing & Profiling"
+    - title: "Week 8: Static Typing"
       children:
         - file: content/week08_static_typing/typing.md
     - title: "Week 9: Intro to Compilation"
@@ -85,7 +85,7 @@ project:
         - file: content/week11_omp/openmp.md
         - file: content/week11_omp/threading.md
         - file: content/week11_omp/concepts.md
-    - title: "Week 12: GPUs"
+    - title: "Week 12: Parallel Computing with MPI"
       children:
         - file: content/week12_mpi/mpi.md
     - title: "Bonus: Exotic topics"

--- a/pixi.toml
+++ b/pixi.toml
@@ -29,6 +29,7 @@ ninja = ">=1.10"
 
 [tasks]
 lab = "jupyter lab"
-book = "python -m ipykernel install --user --name conda-env-se-for-sci-py && myst build --execute --html"
-serve = "python -m ipykernel install --user --name conda-env-se-for-sci-py && myst start --execute"
-pdf = "python -m ipykernel install --user --name conda-env-se-for-sci-py && myst build --execute --pdf"
+install-kernel = "python -m ipykernel install --sys-prefix --name conda-env-se-for-sci-py"
+book = { cmd = "myst build --execute --html", depends-on = ["install-kernel"] }
+serve = { cmd = "myst start --execute", depends-on = ["install-kernel"] }
+pdf = { cmd = "myst build --execute --pdf", depends-on = ["install-kernel"] }


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Changes

- **Fix typo**: 'Hypothosis' -> 'Hypothesis' in content/week02_testing/testing.md (2 occurrences)
- **Fix TOC title**: Week 8 'Static Typing & Profiling' -> 'Static Typing' (profiling content lives in Week 9)
- **Fix TOC title**: Week 12 'GPUs' -> 'Parallel Computing with MPI' (directory and content are MPI-based)
- **Refactor kernel handling**: Split kernel install into a dedicated 'install-kernel' task using --sys-prefix (keeps it inside the pixi environment) instead of --user; build/serve/pdf tasks now depend on it via pixi's depends-on
- **Update docs**: AGENTS.md updated to reflect the new task flow

Assisted-by: OpenCode:Kimi