### PR TITLE
ci: add timeout-minutes to all CI jobs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-book:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -36,7 +36,7 @@ jobs:
 
   build-pyodide:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
 
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-book, build-pyodide, build-slides]
     if: github.event_name == 'push'
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   build-book:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 
@@ -35,6 +36,7 @@ jobs:
 
   build-pyodide:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -51,6 +53,7 @@ jobs:
 
   build-slides:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -69,6 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-book, build-pyodide, build-slides]
     if: github.event_name == 'push'
+    timeout-minutes: 10
     steps:
       - name: Setup Pages
         uses: actions/configure-pages@v6


### PR DESCRIPTION
Building notebooks can get stuck, so adding timeouts.

:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

Prevent CI from getting stuck indefinitely by setting `timeout-minutes` on all jobs:

- **build-book**: 15 min (notebook execution is heaviest)
- **build-pyodide**: 5 min
- **build-slides**: 10 min
- **deploy**: 5 min

Assisted-by: OpenCode:glm-5